### PR TITLE
fix: display verification code validity time message

### DIFF
--- a/src/components/CodeInput/index.tsx
+++ b/src/components/CodeInput/index.tsx
@@ -71,7 +71,7 @@ export const CodeInput = forwardRef<CodeInputHandle, CodeInputProps>(({ value, o
           key={index}
           className={`px-2 py-6 rounded-lg w-full text-center border-2 ${
             error
-              ? "border-red-600 focus:border-red-600"
+              ? "border-red-600 focus:outline-red-400"
               : "border-input-code-border focus:outline-blue-600"
           }  text-inputCodeText font-bold transition-all`}
           type="number"

--- a/src/components/CodeInput/index.tsx
+++ b/src/components/CodeInput/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { error } from "console";
 import React, { useEffect, useRef, useImperativeHandle, forwardRef } from "react";
 
 type CodeInputProps = {
@@ -68,12 +69,20 @@ export const CodeInput = forwardRef<CodeInputHandle, CodeInputProps>(({ value, o
           }}
           value={value[index] || ""}
           key={index}
-          className="px-2 py-6 rounded-lg w-full text-center border-2 border-input-code-border focus:outline-blue-600 text-inputCodeText font-bold transition-all"
+          className={`px-2 py-6 rounded-lg w-full text-center border-2 ${
+            error
+              ? "border-red-600 focus:border-red-600"
+              : "border-input-code-border focus:outline-blue-600"
+          }  text-inputCodeText font-bold transition-all`}
           type="number"
         />
       ))}
     </div>
   );
+<<<<<<< HEAD
 });
 
 CodeInput.displayName = "CodeInput";
+=======
+};
+>>>>>>> c6dd09c (fix code input on error border color)

--- a/src/components/CodeInput/types.ts
+++ b/src/components/CodeInput/types.ts
@@ -2,4 +2,5 @@ export type CodeInputProps = {
   value: (string | null)[];
   onChange?: (value: (string | null)[]) => void;
   onFirstComplete?: (value: (string | null)[]) => void;
+  error?: boolean | null;
 };

--- a/src/features/auth/components/CodeForm.tsx
+++ b/src/features/auth/components/CodeForm.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { Button, CircularProgress } from "@mui/material";
+import { useEmailStore } from "@/stores/emailStore";
+import { CodeInput } from "@/components/CodeInput";
+import { useCredentialLogin } from "../hooks/useCredentialLogin";
+import { useSendCodeEmail } from "../hooks/useSendCodeEmail";
+import { useCountdown } from "../hooks/useCountdown";
+
+export const CodeForm = () => {
+  const { mutate: resendCode, isError: isSendCodeError } = useCredentialLogin();
+  const { mutate: sendEmailCode, error, isPending } = useSendCodeEmail();
+  const { email } = useEmailStore();
+  const [code, setCode] = useState<(string | null)[]>([null, null, null, null]);
+  const { timeLeft, startCountdown, isCountdownActive } = useCountdown();
+
+  const onSubmit = (data: (string | null)[]) => {
+    const code = data.join("");
+
+    sendEmailCode({ code });
+  };
+
+  const sendCode = (email: any) => {
+    resendCode({
+      data: { email },
+    });
+    startCountdown(30);
+  };
+
+  return (
+    <>
+      {!isSendCodeError && (
+        <span className="">
+          Seu código de verificação expira em{" "}
+          <span className="font-bold">30 minutos.</span>
+        </span>
+      )}
+      <div className="flex flex-col gap-3 text-sm">
+        <div className="flex flex-col gap-2 ">
+          <CodeInput
+            value={code}
+            onChange={setCode}
+            onFirstComplete={onSubmit}
+          />
+          {isCountdownActive() ? (
+            <span className="text-gray-400 test-sm">
+              Reenviar código em {timeLeft} segundos
+            </span>
+          ) : (
+            <span
+              onClick={() => sendCode(email)}
+              className="text-blue-600 cursor-pointer"
+            >
+              Reenviar código
+            </span>
+          )}
+        </div>
+      </div>
+
+      {isPending && (
+        <div className="flex justify-center">
+          <CircularProgress size={75} />
+        </div>
+      )}
+
+      {!isPending && (
+        <div className="flex flex-col gap-4">
+          {error && (
+            <span className="text-red-600">
+              Código incorreto! Preencha corretamente ou reenvie o código e
+              tente novamente.
+            </span>
+          )}
+          <Button
+            disabled={!error}
+            className="rounded-lg w-full"
+            variant="outlined"
+            onClick={() => onSubmit(code)}
+          >
+            Confirmar código
+          </Button>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/features/auth/components/CodeForm.tsx
+++ b/src/features/auth/components/CodeForm.tsx
@@ -67,6 +67,7 @@ export const CodeForm = () => {
             value={code}
             onChange={setCode}
             onFirstComplete={onSubmit}
+            error={error ? true : false}
           />
           {timeLeftResendCode > 0 ? (
             <span className="text-gray-400 test-sm">

--- a/src/features/auth/hooks/useCountdown.ts
+++ b/src/features/auth/hooks/useCountdown.ts
@@ -1,29 +1,23 @@
 import { useEffect, useState } from "react";
 
 export const useCountdown = () => {
-  const [countdown, setCountdown] = useState(30);
-  const [isActive, setIsActive] = useState(false);
+  const [timeLeft, setTimeLeft] = useState<number>(0);
 
   useEffect(() => {
-    if (!isActive || countdown <= 0) {
-      setIsActive(false);
-
-      setCountdown(30);
-
-      return
+    if (timeLeft > 0) {
+      const timer = setInterval(() => {
+        setTimeLeft(timeLeft - 1);
+      }, 1000);
+      return () => clearInterval(timer);
     }
+    return;
+  }, [timeLeft]);
 
-    const timer = setInterval(() => {
-      setCountdown((prev) => prev - 1);
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, [isActive, countdown]);
-
-  const startCountdown = () => {
-    setCountdown(countdown);
-    setIsActive(true);
-  };
-
-  return { countdown, isActive, startCountdown };
+  function startCountdown(seconds: number) {
+    setTimeLeft(seconds);
+  }
+  function isCountdownActive() {
+    return timeLeft > 0;
+  }
+  return { timeLeft, startCountdown, isCountdownActive };
 };

--- a/src/features/auth/hooks/useCountdown.ts
+++ b/src/features/auth/hooks/useCountdown.ts
@@ -13,10 +13,10 @@ export const useCountdown = () => {
     return;
   }, [timeLeft]);
 
-  function startCountdown(seconds: number) {
+  function startCountdown(seconds: number): void {
     setTimeLeft(seconds);
   }
-  function isCountdownActive() {
+  function isCountdownActive(): boolean {
     return timeLeft > 0;
   }
   return { timeLeft, startCountdown, isCountdownActive };

--- a/src/features/auth/hooks/useCountdown.ts
+++ b/src/features/auth/hooks/useCountdown.ts
@@ -16,8 +16,5 @@ export const useCountdown = () => {
   function startCountdown(seconds: number): void {
     setTimeLeft(seconds);
   }
-  function isCountdownActive(): boolean {
-    return timeLeft > 0;
-  }
-  return { timeLeft, startCountdown, isCountdownActive };
+  return { timeLeft, startCountdown };
 };


### PR DESCRIPTION
Corrige a ausência da mensagem de validade do código de verificação. Adiciona contagem regressiva de 30s para "Reenviar código" (ex: "Reenviar código em X segundos"), usando um novo hook `useCountdown`, conforme design do Figma.

Resolve o bug: https://trello.com/c/zd4ClxEJ/37-altera%C3%A7%C3%A3o-validade-c%C3%B3digo-de-verifica%C3%A7%C3%A3o