### PR TITLE
feat: use NEXT_PUBLIC_API_URL env var for API base URL

### DIFF
--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "https://conecta-bem-back.vercel.app/",
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "https://conecta-bem-back.vercel.app/",
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- `src/libs/api.ts` now uses `process.env.NEXT_PUBLIC_API_URL` instead of a hardcoded URL
- Falls back to `https://conecta-bem-back.vercel.app/` when the variable is not set (production)
- Allows pointing to a local backend during development

## Local setup

In `.env.local`:
```
NEXT_PUBLIC_API_URL=http://localhost:3000
```

## Test plan

- [ ] Verify frontend connects to local backend in dev
- [ ] Verify production fallback to Vercel URL works when variable is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)