### PR TITLE
chore: add .claude/napkin.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 
 *storybook.log
 .env*.local
+
+# Claude Code napkin (per-user agent memory)
+.claude/napkin.md


### PR DESCRIPTION
## Summary
- Add `.claude/napkin.md` to `.gitignore` to prevent agent memory files from being versioned
- Napkin files are per-user Claude Code agent memory and should remain local

🤖 Generated with [Claude Code](https://claude.com/claude-code)