### PR TITLE
test(e2e): habilitar fluxo de login e cadastro com bypass de OTP

### DIFF
--- a/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/cadastro.cy.js
+++ b/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/cadastro.cy.js
@@ -1,20 +1,11 @@
-import {
-  createTempAccount,
-  enterOTPCode,
-  extractOTPCode,
-  getEmailContent,
-  getLatestEmail,
-} from "../../utils/mailtm.js";
+import { enterOTPCode } from "../../utils/mailtm.js";
 
 describe("Fluxo de Cadastro", () => {
-  let emailAddress;
-  let token;
-
   beforeEach(() => {
     cy.visit("/");
 
     // Abre o modal de cadastro/login
-    cy.get(".MuiButtonBase-root").click();
+    cy.get(".MuiButtonBase-root").first().click();
   });
 
   context("Validações do campo de e-mail", () => {
@@ -31,42 +22,23 @@ describe("Fluxo de Cadastro", () => {
     });
   });
 
-  context("Cadastro completo com código via e-mail (Mail.tm)", () => {
-    before(() => {
-      createTempAccount().then((res) => {
-        emailAddress = res.emailAddress;
-        token = res.token;
-      });
-    });
+  context("Cadastro completo de paciente com bypass de OTP", () => {
+    it("Realiza cadastro completo usando email @test.conectabem.com e OTP 0000", () => {
+      // Usa email único por execução para não colidir com runs anteriores
+      const email = `qa-paciente-${Date.now()}@test.conectabem.com`;
 
-    // TODO: Depends on external Mail.tm service which is unreliable in CI.
-    // Re-enable once OTP flow is mockable or Mail.tm is replaced.
-    it.skip("Realiza cadastro com sucesso usando OTP recebido por e-mail", () => {
-      cy.get('input[name="email"]').type(emailAddress);
+      cy.get('input[name="email"]').type(email);
       cy.get(".gap-7 > .MuiButtonBase-root").click();
 
-      cy.wait(5000);
+      // Bypass ativo: sem espera de e-mail externo, OTP fixo 0000
+      enterOTPCode("0000");
 
-      getLatestEmail(token)
-        .then((message) => {
-          return getEmailContent(token, message.id);
-        })
-        .then((emailRes) => {
-          const emailBody = emailRes.body.text || emailRes.body.html || "";
-
-          const codigo = extractOTPCode(emailBody);
-          if (!codigo) {
-            throw new Error("Não foi possível extrair o código OTP");
-          }
-
-          enterOTPCode(codigo);
-        });
-
-      // Continuação do fluxo de cadastro
+      // Seleciona tipo de conta: Paciente
       cy.get(".gap-5 > :nth-child(1)").click();
       cy.get(".css-1bqevrn > a > .MuiButtonBase-root").click();
 
-      cy.get('input[name="name"]').type("Nome Teste");
+      // Dados pessoais
+      cy.get('input[name="name"]').type("QA Paciente Teste");
       cy.get('input[placeholder="DD/MM/AAAA"]').then(($input) => {
         $input.prop("readOnly", false);
         cy.wrap($input).scrollIntoView().clear({ force: true }).type("28121999", { force: true });
@@ -78,13 +50,16 @@ describe("Fluxo de Cadastro", () => {
       cy.wait(5000);
       cy.get("form.flex > .MuiButton-root").click();
 
-      cy.get(":nth-child(1) > .flex-col > .flex-wrap > :nth-child(1) > .p-2").click();
-      cy.get(":nth-child(2) > .flex-col > .flex-wrap > :nth-child(1) > .p-2").click();
+      // Especialidades
+      cy.get(":nth-child(1) > .flex-col > .flex-wrap > :nth-child(1) > button").click();
+      cy.get(":nth-child(2) > .flex-col > .flex-wrap > :nth-child(1) > button").click();
       cy.get(".md\\:max-w-\\[450px\\] > .gap-8 > .MuiButtonBase-root").click();
 
+      // Preferências de atendimento
       cy.get(":nth-child(2) > .p-2").click();
       cy.get(".flex-col-reverse > .MuiButton-contained").click();
 
+      // Termos
       cy.get(".PrivateSwitchBase-input").click();
       cy.get(".gap-6 > .MuiButtonBase-root").click();
 

--- a/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/login.bypass.cy.js
+++ b/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/login.bypass.cy.js
@@ -1,0 +1,33 @@
+import { enterOTPCode } from "../../utils/mailtm.js";
+
+/**
+ * Testes de login com bypass de OTP para usuários @test.conectabem.com.
+ *
+ * Pré-requisito: ambiente deve ter NODE_ENV !== "production" e TEST_OTP_ENABLED=true.
+ * Os usuários seed (patient e professional) devem estar presentes no banco — rode
+ * `npm run seed:test-users` na API antes de executar essa suite.
+ */
+describe("Login com bypass de OTP — usuários de teste", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get(".MuiButtonBase-root").first().click();
+  });
+
+  it("Paciente faz login com OTP 0000", () => {
+    cy.get('input[name="email"]').type("patient@test.conectabem.com");
+    cy.get(".gap-7 > .MuiButtonBase-root").click();
+
+    enterOTPCode("0000");
+
+    cy.url({ timeout: 15000 }).should("not.include", "/auth");
+  });
+
+  it("Profissional faz login com OTP 0000", () => {
+    cy.get('input[name="email"]').type("professional@test.conectabem.com");
+    cy.get(".gap-7 > .MuiButtonBase-root").click();
+
+    enterOTPCode("0000");
+
+    cy.url({ timeout: 15000 }).should("not.include", "/auth");
+  });
+});

--- a/cypress/e2e/utils/mailtm.js
+++ b/cypress/e2e/utils/mailtm.js
@@ -87,13 +87,14 @@ export function extractOTPCode(emailBody) {
 
 /**
  * Digita o código OTP nos campos da tela.
+ * Usa aria-label para selecionar cada dígito — mais robusto que seletores CSS.
  */
 export function enterOTPCode(codigo) {
   const digitos = codigo.split("");
   digitos.forEach((digito, index) => {
-    cy.get(`.gap-3 > .flex-col > .flex > :nth-child(${index + 1})`)
+    cy.get(`input[aria-label="Dígito ${index + 1} de ${digitos.length}"]`)
       .should("be.visible")
       .clear()
-      .type(digito, { delay: 200 });
+      .type(digito, { delay: 100 });
   });
 }


### PR DESCRIPTION
Remove a dependência do Mail.tm nos testes E2E de autenticação e habilita o fluxo completo usando o bypass de OTP já implementado no backend.

## O que foi feito

- **`enterOTPCode`** — substituído o seletor CSS frágil (`.gap-3 > .flex-col > .flex > :nth-child()`) pelo `aria-label` que foi adicionado nos inputs do `CodeInput` no PR #200. Mais robusto e sem acoplamento com classes internas do MUI.

- **`login.bypass.cy.js`** (novo) — testa login de paciente e profissional usando `@test.conectabem.com` + OTP `0000`. Pré-requisito: usuários seed presentes no banco (`npm run seed:test-users` na API).

- **`cadastro.cy.js`** — remove a dependência do Mail.tm, re-habilita o teste de cadastro completo usando o mesmo bypass. Atualiza o seletor das especialidades de `> .p-2` para `> button` após a refatoração de acessibilidade do `SpecialtyStep` (#200).

## Pré-requisitos para rodar

- `NODE_ENV !== "production"` e `TEST_OTP_ENABLED=true` no ambiente da API
- Usuários seed criados: `npm run seed:test-users` (API)
- `baseUrl` do Cypress apontando para ambiente de staging, não produção