### PR TITLE
fix(auth): corrigir acessibilidade, validação e fluxo de registro

### DIFF
--- a/src/__tests__/test_pages/registro-profissional.test.tsx
+++ b/src/__tests__/test_pages/registro-profissional.test.tsx
@@ -31,7 +31,7 @@ describe("Registro Profissional Page", () => {
     expect(screen.getByText("Data de Nascimento")).toBeInTheDocument();
     expect(screen.getByText("CEP Residencial")).toBeInTheDocument();
     expect(screen.getByText("Número")).toBeInTheDocument();
-    expect(screen.getByText("Longradouro")).toBeInTheDocument();
+    expect(screen.getByText("Logradouro")).toBeInTheDocument();
     expect(screen.getByText("Bairro")).toBeInTheDocument();
     expect(screen.getByText("Cidade")).toBeInTheDocument();
     expect(screen.getByText("Estado")).toBeInTheDocument();

--- a/src/app/(auth)/auth/confirmar-codigo/page.tsx
+++ b/src/app/(auth)/auth/confirmar-codigo/page.tsx
@@ -37,7 +37,7 @@ export default function ConfirmCode() {
       redirectUrl={redirectUrl}
     />
   ) : (
-    <main className="flex justify-center">
+    <div className="flex justify-center">
       <div className="flex flex-col justify-center gap-8 md:max-w-[450px]">
         <TitleCode />
 
@@ -59,6 +59,6 @@ export default function ConfirmCode() {
           Mudar método
         </Button>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(auth)/auth/page.tsx
+++ b/src/app/(auth)/auth/page.tsx
@@ -5,7 +5,7 @@ import { SocialNetwork } from "@/features/auth/components/SocialNetwork/SocialNe
 
 export default function register() {
   return (
-    <main className="flex md:justify-center">
+    <div className="flex md:justify-center">
       <div className="flex w-full flex-col gap-8 md:max-w-[450px]">
         <FormMultiStep.Header>
           <FormMultiStep.Title>Prazer ter você no ConectaBem!</FormMultiStep.Title>
@@ -17,6 +17,6 @@ export default function register() {
           <SocialNetwork />
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(auth)/auth/registro-paciente/page.tsx
+++ b/src/app/(auth)/auth/registro-paciente/page.tsx
@@ -2,10 +2,10 @@ import { PatientRegister } from "@/features/auth/components/PatientRegister";
 
 export default function registroPaciente() {
   return (
-    <main className="flex items-start justify-center">
+    <div className="flex items-start justify-center">
       <div className="flex w-full flex-col gap-8 md:max-w-[450px]">
         <PatientRegister />
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(auth)/auth/registro-profissional/page.tsx
+++ b/src/app/(auth)/auth/registro-profissional/page.tsx
@@ -2,10 +2,10 @@ import { ProfissionalRegister } from "@/features/auth/components/ProfissionalReg
 
 export default function register() {
   return (
-    <main className="flex items-start justify-center">
+    <div className="flex items-start justify-center">
       <div className="flex w-full flex-col gap-8 md:max-w-[450px]">
         <ProfissionalRegister />
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(auth)/auth/registro/page.tsx
+++ b/src/app/(auth)/auth/registro/page.tsx
@@ -33,7 +33,7 @@ export default function Registro() {
   const handleClose = () => setOpen(false);
 
   return (
-    <main className="flex w-full justify-center">
+    <div className="flex w-full justify-center">
       <div className="mt-8 flex w-full flex-col gap-8 md:max-w-[450px]">
         <FormMultiStep.Header className="gap-4">
           <FormMultiStep.Title>Tudo pronto para começar</FormMultiStep.Title>
@@ -147,6 +147,6 @@ export default function Registro() {
           </Typography>
         </Box>
       </Modal>
-    </main>
+    </div>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -123,19 +123,25 @@ export const Header = () => {
                   onMouseEnter={!item.menuitemlink.url ? () => setHoveredItem(index) : undefined}
                   onMouseLeave={!item.menuitemlink.url ? () => setHoveredItem(null) : undefined}
                 >
-                  <button
-                    type="button"
-                    className="flex items-center gap-2 font-semibold text-secondary-900"
-                  >
-                    {item.menuitemlink.url ? (
-                      <Link href={item.menuitemlink.url || "#"}>{item.menuitemtext}</Link>
-                    ) : (
-                      <>
-                        {item.menuitemtext}
-                        <ChevronDownIcon className="h-4 w-4 text-[#9790A2] transition-transform" />
-                      </>
-                    )}
-                  </button>
+                  {item.menuitemlink.url ? (
+                    <Link
+                      href={item.menuitemlink.url}
+                      className="flex items-center gap-2 font-semibold text-secondary-900"
+                    >
+                      {item.menuitemtext}
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      className="flex items-center gap-2 font-semibold text-secondary-900"
+                    >
+                      {item.menuitemtext}
+                      <ChevronDownIcon
+                        aria-hidden="true"
+                        className="h-4 w-4 text-[#9790A2] transition-transform"
+                      />
+                    </button>
+                  )}
 
                   {hoveredItem === index && (
                     <div className="absolute top-full left-0 z-50 w-48 animate-fade-in whitespace-normal rounded-lg bg-white py-2 shadow-lg ring-1 ring-black ring-opacity-5">

--- a/src/features/auth/components/AuthForm/AuthForm.tsx
+++ b/src/features/auth/components/AuthForm/AuthForm.tsx
@@ -40,7 +40,7 @@ export const AuthForm = () => {
   return (
     <form className="flex flex-col gap-7" onSubmit={onSubmit}>
       <div className="flex flex-col gap-2">
-        <label>
+        <label htmlFor={emailId}>
           E-mail<span className="text-red-600">*</span>
         </label>
         <TextField

--- a/src/features/auth/components/CodeForm/CodeForm.tsx
+++ b/src/features/auth/components/CodeForm/CodeForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { useEffect, useRef, useState } from "react";
 import { CodeInput, type CodeInputHandle } from "@/components/CodeInput/CodeInput";
+import { api } from "@/libs/api";
 import { useUserStore } from "@/stores/userSessionStore";
 import { useCountdown } from "../../hooks/useCountdown";
 import { useCredentialLogin } from "../../hooks/useCredentialLogin";
@@ -16,7 +17,7 @@ type CodeFormProps = {
 export const CodeForm = ({ onValidationSuccess }: CodeFormProps) => {
   const router = useRouter();
   const { mutate: resendCode } = useCredentialLogin();
-  const { email } = useUserStore();
+  const { email, setPendingToken } = useUserStore();
   const [code, setCode] = useState<(string | null)[]>([null, null, null, null]);
   const [isPending, setPending] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
@@ -39,22 +40,33 @@ export const CodeForm = ({ onValidationSuccess }: CodeFormProps) => {
     setCode([null, null, null, null]);
     setError(false);
     setPending(true);
-    const result = await signIn("credentials", {
-      email,
-      code,
-      redirect: false,
-    });
-    setPending(false);
 
-    if (result?.ok) {
-      onValidationSuccess(result.status);
-    }
+    try {
+      const response = await api.post("/auth/checkOTP", { email, OTP: code });
+      const responseData = response.data;
 
-    if (result?.error === "ACCOUNT_PENDING") {
-      router.push("/auth/registro");
-    } else if (result?.error) {
+      if (responseData.user?.status === "pending") {
+        setPendingToken(responseData.token);
+        router.push("/auth/registro");
+        return;
+      }
+
+      const result = await signIn("credentials", {
+        token: responseData.token,
+        redirect: false,
+      });
+
+      if (result?.ok) {
+        onValidationSuccess(result.status);
+      } else {
+        setError(true);
+        codeInputRef.current?.focusOnFirstInput();
+      }
+    } catch {
       setError(true);
       codeInputRef.current?.focusOnFirstInput();
+    } finally {
+      setPending(false);
     }
   };
 

--- a/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
     .string()
     .min(3, "Nome deve ter pelo menos 3 caracteres")
     .regex(
-      /^[A-Za-zÀ-ÿ-]+(?: [A-Za-zÀ-ÿ-]+)*$/,
+      /^[A-Za-zÀ-ÖØ-öø-ÿ-]+(?: [A-Za-zÀ-ÖØ-öø-ÿ-]+)*$/,
       "O nome deve conter apenas letras e um espaço entre as palavras",
     ),
   birthdayDate: z
@@ -158,7 +158,7 @@ export const PersonalDataStep = () => {
     const rawValue = e.target.value;
 
     const onlyLettersAndSpace = rawValue
-      .replace(/[^A-Za-zÀ-ÿ\s-]/g, "")
+      .replace(/[^A-Za-zÀ-ÖØ-öø-ÿ\s-]/g, "")
       .replace(/\s+/g, " ")
       .trimStart();
 

--- a/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
@@ -190,7 +190,6 @@ export const PersonalDataStep = () => {
           placeholder="Nome e Sobrenome"
           id={nameId}
           value={nameInput}
-          required
           autoComplete="name"
           helperText={errors.name?.message}
           error={!!errors.name}

--- a/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
     .string()
     .min(3, "Nome deve ter pelo menos 3 caracteres")
     .regex(
-      /^[A-Za-zÀ-ú]+(?: [A-Za-zÀ-ú]+)*$/,
+      /^[A-Za-zÀ-ÿ-]+(?: [A-Za-zÀ-ÿ-]+)*$/,
       "O nome deve conter apenas letras e um espaço entre as palavras",
     ),
   birthdayDate: z
@@ -73,6 +73,13 @@ export const PersonalDataStep = () => {
   const { updateFields, changeStep } = usePatientRegisterStore();
   const [nameInput, setNameInput] = useState("");
   const nameId = useId();
+  const birthdayId = useId();
+  const cepId = useId();
+  const enderecoId = useId();
+  const numeroId = useId();
+  const bairroId = useId();
+  const cidadeId = useId();
+  const estadoId = useId();
 
   const fieldRefs = {
     name: useRef<HTMLDivElement | null>(null),
@@ -151,7 +158,7 @@ export const PersonalDataStep = () => {
     const rawValue = e.target.value;
 
     const onlyLettersAndSpace = rawValue
-      .replace(/[^A-Za-zÀ-ú\s]/g, "")
+      .replace(/[^A-Za-zÀ-ÿ\s-]/g, "")
       .replace(/\s+/g, " ")
       .trimStart();
 
@@ -180,7 +187,7 @@ export const PersonalDataStep = () => {
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
       {/* Nome */}
       <div ref={fieldRefs.name} className="flex flex-col gap-2">
-        <label className={errors.name ? "text-red-600" : ""}>
+        <label htmlFor={nameId} className={errors.name ? "text-red-600" : ""}>
           Nome <span className="text-red-600">*</span>
         </label>
 
@@ -193,14 +200,17 @@ export const PersonalDataStep = () => {
           autoComplete="name"
           helperText={errors.name?.message}
           error={!!errors.name}
-          inputProps={{ "aria-required": "true", ...(errors.name && { "aria-describedby": "error-name" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.name && { "aria-describedby": "error-name" }),
+          }}
           FormHelperTextProps={{ id: "error-name" }}
         />
       </div>
 
       {/* Data de nascimento */}
       <div ref={fieldRefs.birthdayDate} className="flex flex-col gap-2">
-        <label className={errors.birthdayDate ? "text-red-600" : ""}>
+        <label htmlFor={birthdayId} className={errors.birthdayDate ? "text-red-600" : ""}>
           Data de Nascimento <span className="text-red-600">*</span>
         </label>
         <DatePicker
@@ -210,6 +220,7 @@ export const PersonalDataStep = () => {
           slotProps={{
             textField: {
               inputProps: {
+                id: birthdayId,
                 placeholder: "DD/MM/AAAA",
                 autoComplete: "bday",
                 "aria-required": "true",
@@ -230,11 +241,12 @@ export const PersonalDataStep = () => {
 
       {/* CEP */}
       <div ref={fieldRefs.cepResidencial} className="flex flex-col gap-2">
-        <label className={errors.cepResidencial ? "text-red-600" : ""}>
+        <label htmlFor={cepId} className={errors.cepResidencial ? "text-red-600" : ""}>
           CEP Residencial <span className="text-red-600">*</span>
         </label>
         <CEPField
           {...register("cepResidencial")}
+          id={cepId}
           onChange={(e) =>
             setValue("cepResidencial", e.target.value, {
               shouldValidate: true,
@@ -243,18 +255,22 @@ export const PersonalDataStep = () => {
           helperText={errors.cepResidencial?.message}
           error={!!errors.cepResidencial}
           autoComplete="postal-code"
-          inputProps={{ "aria-required": "true", ...(errors.cepResidencial && { "aria-describedby": "error-cep" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.cepResidencial && { "aria-describedby": "error-cep" }),
+          }}
           FormHelperTextProps={{ id: "error-cep" }}
         />
       </div>
 
       {/* Logradouro */}
       <div ref={fieldRefs.enderecoResidencial} className="flex flex-col gap-2">
-        <label className={errors.enderecoResidencial ? "text-red-600" : ""}>
+        <label htmlFor={enderecoId} className={errors.enderecoResidencial ? "text-red-600" : ""}>
           Logradouro <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("enderecoResidencial")}
+          id={enderecoId}
           onChange={(e) =>
             setValue("enderecoResidencial", e.target.value, {
               shouldValidate: true,
@@ -263,33 +279,41 @@ export const PersonalDataStep = () => {
           placeholder="Nome da rua / avenida"
           error={!!errors.enderecoResidencial}
           helperText={errors.enderecoResidencial?.message}
-          inputProps={{ "aria-required": "true", ...(errors.enderecoResidencial && { "aria-describedby": "error-endereco" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.enderecoResidencial && { "aria-describedby": "error-endereco" }),
+          }}
           FormHelperTextProps={{ id: "error-endereco" }}
         />
       </div>
 
       {/* Número */}
       <div ref={fieldRefs.numeroResidencial} className="flex flex-col gap-2">
-        <label className={errors.numeroResidencial ? "text-red-600" : ""}>
+        <label htmlFor={numeroId} className={errors.numeroResidencial ? "text-red-600" : ""}>
           Número <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("numeroResidencial")}
+          id={numeroId}
           placeholder="0000"
           error={!!errors.numeroResidencial}
           helperText={errors.numeroResidencial?.message}
-          inputProps={{ "aria-required": "true", ...(errors.numeroResidencial && { "aria-describedby": "error-numero" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.numeroResidencial && { "aria-describedby": "error-numero" }),
+          }}
           FormHelperTextProps={{ id: "error-numero" }}
         />
       </div>
 
       {/* Bairro */}
       <div ref={fieldRefs.bairroResidencial} className="flex flex-col gap-2">
-        <label className={errors.bairroResidencial ? "text-red-600" : ""}>
+        <label htmlFor={bairroId} className={errors.bairroResidencial ? "text-red-600" : ""}>
           Bairro <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("bairroResidencial")}
+          id={bairroId}
           onChange={(e) =>
             setValue("bairroResidencial", e.target.value, {
               shouldValidate: true,
@@ -298,18 +322,22 @@ export const PersonalDataStep = () => {
           placeholder="Nome do bairro"
           error={!!errors.bairroResidencial}
           helperText={errors.bairroResidencial?.message}
-          inputProps={{ "aria-required": "true", ...(errors.bairroResidencial && { "aria-describedby": "error-bairro" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.bairroResidencial && { "aria-describedby": "error-bairro" }),
+          }}
           FormHelperTextProps={{ id: "error-bairro" }}
         />
       </div>
 
       {/* Cidade */}
       <div ref={fieldRefs.cidadeResidencial} className="flex flex-col gap-2">
-        <label className={errors.cidadeResidencial ? "text-red-600" : ""}>
+        <label htmlFor={cidadeId} className={errors.cidadeResidencial ? "text-red-600" : ""}>
           Cidade <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("cidadeResidencial")}
+          id={cidadeId}
           onChange={(e) =>
             setValue("cidadeResidencial", e.target.value, {
               shouldValidate: true,
@@ -318,18 +346,22 @@ export const PersonalDataStep = () => {
           placeholder="Nome da cidade"
           error={!!errors.cidadeResidencial}
           helperText={errors.cidadeResidencial?.message}
-          inputProps={{ "aria-required": "true", ...(errors.cidadeResidencial && { "aria-describedby": "error-cidade" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.cidadeResidencial && { "aria-describedby": "error-cidade" }),
+          }}
           FormHelperTextProps={{ id: "error-cidade" }}
         />
       </div>
 
       {/* Estado */}
       <div ref={fieldRefs.estadoResidencial} className="flex flex-col gap-2">
-        <label className={errors.estadoResidencial ? "text-red-600" : ""}>
+        <label htmlFor={estadoId} className={errors.estadoResidencial ? "text-red-600" : ""}>
           Estado <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("estadoResidencial")}
+          id={estadoId}
           onChange={(e) =>
             setValue("estadoResidencial", e.target.value, {
               shouldValidate: true,
@@ -338,12 +370,15 @@ export const PersonalDataStep = () => {
           placeholder="Nome do estado"
           error={!!errors.estadoResidencial}
           helperText={errors.estadoResidencial?.message}
-          inputProps={{ "aria-required": "true", ...(errors.estadoResidencial && { "aria-describedby": "error-estado" }) }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.estadoResidencial && { "aria-describedby": "error-estado" }),
+          }}
           FormHelperTextProps={{ id: "error-estado" }}
         />
       </div>
 
-      <p className="text-gray-500 text-xs">
+      <p className="text-gray-600 text-xs">
         Campos Obrigatórios (<span>*</span>)
       </p>
 

--- a/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
@@ -193,7 +193,7 @@ export const PersonalDataStep = () => {
           autoComplete="name"
           helperText={errors.name?.message}
           error={!!errors.name}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-name" }}
+          inputProps={{ "aria-required": "true", ...(errors.name && { "aria-describedby": "error-name" }) }}
           FormHelperTextProps={{ id: "error-name" }}
         />
       </div>
@@ -213,11 +213,10 @@ export const PersonalDataStep = () => {
                 placeholder: "DD/MM/AAAA",
                 autoComplete: "bday",
                 "aria-required": "true",
-                "aria-describedby": "error-birthdate",
+                ...(errors.birthdayDate && { "aria-describedby": "error-birthdate" }),
               },
               helperText: errors.birthdayDate?.message,
               error: !!errors.birthdayDate,
-              required: true,
               FormHelperTextProps: { id: "error-birthdate" },
             },
           }}
@@ -244,7 +243,7 @@ export const PersonalDataStep = () => {
           helperText={errors.cepResidencial?.message}
           error={!!errors.cepResidencial}
           autoComplete="postal-code"
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-cep" }}
+          inputProps={{ "aria-required": "true", ...(errors.cepResidencial && { "aria-describedby": "error-cep" }) }}
           FormHelperTextProps={{ id: "error-cep" }}
         />
       </div>
@@ -264,7 +263,7 @@ export const PersonalDataStep = () => {
           placeholder="Nome da rua / avenida"
           error={!!errors.enderecoResidencial}
           helperText={errors.enderecoResidencial?.message}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-endereco" }}
+          inputProps={{ "aria-required": "true", ...(errors.enderecoResidencial && { "aria-describedby": "error-endereco" }) }}
           FormHelperTextProps={{ id: "error-endereco" }}
         />
       </div>
@@ -279,7 +278,7 @@ export const PersonalDataStep = () => {
           placeholder="0000"
           error={!!errors.numeroResidencial}
           helperText={errors.numeroResidencial?.message}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-numero" }}
+          inputProps={{ "aria-required": "true", ...(errors.numeroResidencial && { "aria-describedby": "error-numero" }) }}
           FormHelperTextProps={{ id: "error-numero" }}
         />
       </div>
@@ -299,7 +298,7 @@ export const PersonalDataStep = () => {
           placeholder="Nome do bairro"
           error={!!errors.bairroResidencial}
           helperText={errors.bairroResidencial?.message}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-bairro" }}
+          inputProps={{ "aria-required": "true", ...(errors.bairroResidencial && { "aria-describedby": "error-bairro" }) }}
           FormHelperTextProps={{ id: "error-bairro" }}
         />
       </div>
@@ -319,7 +318,7 @@ export const PersonalDataStep = () => {
           placeholder="Nome da cidade"
           error={!!errors.cidadeResidencial}
           helperText={errors.cidadeResidencial?.message}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-cidade" }}
+          inputProps={{ "aria-required": "true", ...(errors.cidadeResidencial && { "aria-describedby": "error-cidade" }) }}
           FormHelperTextProps={{ id: "error-cidade" }}
         />
       </div>
@@ -339,7 +338,7 @@ export const PersonalDataStep = () => {
           placeholder="Nome do estado"
           error={!!errors.estadoResidencial}
           helperText={errors.estadoResidencial?.message}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-estado" }}
+          inputProps={{ "aria-required": "true", ...(errors.estadoResidencial && { "aria-describedby": "error-estado" }) }}
           FormHelperTextProps={{ id: "error-estado" }}
         />
       </div>

--- a/src/features/auth/components/PatientRegister/SpecialityStep/index.tsx
+++ b/src/features/auth/components/PatientRegister/SpecialityStep/index.tsx
@@ -16,7 +16,12 @@ const schema = z.object({
 });
 
 export const SpecialtyStep = () => {
-  const { setValue, handleSubmit, watch } = useForm<Data>({
+  const {
+    setValue,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<Data>({
     mode: "all",
     resolver: zodResolver(schema),
     defaultValues: { specialties: [], servicePreferences: [] },
@@ -46,6 +51,11 @@ export const SpecialtyStep = () => {
           onChange={(selecteds) => setValue("specialties", selecteds)}
           selecteds={selectedSpecialties}
         />
+        {errors.specialties && (
+          <p className="text-red-600 text-sm" role="alert">
+            {errors.specialties.message}
+          </p>
+        )}
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src/features/auth/components/ProfissionalRegister/CompleteProfileStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/CompleteProfileStep.tsx
@@ -82,7 +82,7 @@ export const CompleteProfileStep = () => {
 
   return (
     <form className="flex flex-col gap-8">
-      <span>Estamos felizes em ter voce aqui, {name}. Vamos iniciar sua jornada?</span>
+      <span>Estamos felizes em ter você aqui, {name}. Vamos iniciar sua jornada?</span>
 
       <div className="relative flex items-center justify-center">
         <ImageUpload onChange={onChangeImage} value={photo} className="mb-4" />

--- a/src/features/auth/components/ProfissionalRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/PersonalDataStep.tsx
@@ -28,7 +28,7 @@ const schema = z.object({
     .string()
     .min(3, "Nome deve ter pelo menos 3 caracteres")
     .regex(
-      /^[A-Za-zÀ-ú]+(?: [A-Za-zÀ-ú]+)*$/,
+      /^[A-Za-zÀ-ÖØ-öø-ÿ-]+(?: [A-Za-zÀ-ÖØ-öø-ÿ-]+)*$/,
       "O nome deve conter apenas letras e um espaço entre as palavras",
     ),
   birthdate: z
@@ -92,6 +92,13 @@ type Data = z.infer<typeof schema>;
 export const PersonalDataStep = () => {
   const { changeStep, updateFields } = useProfissionalRegisterStore();
   const nameId = useId();
+  const birthdateId = useId();
+  const cepResidencialId = useId();
+  const enderecoResidencialId = useId();
+  const numeroResidencialId = useId();
+  const bairroResidencialId = useId();
+  const cidadeResidencialId = useId();
+  const estadoResidencialId = useId();
 
   const fieldRefs = {
     name: useRef<HTMLDivElement>(null),
@@ -173,7 +180,7 @@ export const PersonalDataStep = () => {
     const rawValue = e.target.value;
 
     const onlyLettersAndSpace = rawValue
-      .replace(/[^A-Za-zÀ-ú\s]/g, "")
+      .replace(/[^A-Za-zÀ-ÖØ-öø-ÿ\s-]/g, "")
       .replace(/\s+/g, " ")
       .trimStart();
 
@@ -193,7 +200,7 @@ export const PersonalDataStep = () => {
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-6">
       <div ref={fieldRefs.name} className="flex flex-col gap-2">
-        <label className={errors.name ? "text-red-600" : ""}>
+        <label htmlFor={nameId} className={errors.name ? "text-red-600" : ""}>
           Nome Completo <span className="text-red-600">*</span>
         </label>
         <TextField
@@ -206,13 +213,16 @@ export const PersonalDataStep = () => {
           autoComplete="name"
           helperText={errors.name?.message}
           error={!!errors.name}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-name" }}
-          FormHelperTextProps={{ id: "error-name" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.name && { "aria-describedby": "error-prof-name" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-name" }}
         />
       </div>
 
       <div ref={fieldRefs.birthdate} className="flex flex-col gap-2">
-        <label className={errors.birthdate ? "text-red-600" : ""}>
+        <label htmlFor={birthdateId} className={errors.birthdate ? "text-red-600" : ""}>
           Data de Nascimento <span className="text-red-600">*</span>
         </label>
         <DatePicker
@@ -222,14 +232,15 @@ export const PersonalDataStep = () => {
           slotProps={{
             textField: {
               inputProps: {
+                id: birthdateId,
                 placeholder: "DD/MM/AAAA",
                 autoComplete: "bday",
                 "aria-required": "true",
-                "aria-describedby": "error-birthdate",
+                ...(errors.birthdate && { "aria-describedby": "error-prof-birthdate" }),
               },
               helperText: errors.birthdate?.message,
               error: !!errors.birthdate,
-              FormHelperTextProps: { id: "error-birthdate" },
+              FormHelperTextProps: { id: "error-prof-birthdate" },
             },
           }}
           onChange={(date) =>
@@ -241,17 +252,21 @@ export const PersonalDataStep = () => {
       </div>
 
       <div ref={fieldRefs.cepResidencial} className="flex flex-col gap-2">
-        <label className={errors.cepResidencial ? "text-red-600" : ""}>
+        <label htmlFor={cepResidencialId} className={errors.cepResidencial ? "text-red-600" : ""}>
           CEP Residencial <span className="text-red-600">*</span>
         </label>
         <CEPField
           {...register("cepResidencial")}
+          id={cepResidencialId}
           onChange={(e) => setValue("cepResidencial", e.target.value, { shouldValidate: true })}
           error={!!errors.cepResidencial}
           helperText={errors.cepResidencial?.message}
           autoComplete="postal-code"
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-cep" }}
-          FormHelperTextProps={{ id: "error-cep" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.cepResidencial && { "aria-describedby": "error-prof-cep" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-cep" }}
         />
         <div className="flex justify-end">
           <span className="cursor-pointer font-normal text-[#1D1B20] text-base underline">
@@ -261,11 +276,15 @@ export const PersonalDataStep = () => {
       </div>
 
       <div ref={fieldRefs.enderecoResidencial} className="flex flex-col gap-2">
-        <label className={errors.enderecoResidencial ? "text-red-600" : ""}>
-          Longradouro <span className="text-red-600">*</span>
+        <label
+          htmlFor={enderecoResidencialId}
+          className={errors.enderecoResidencial ? "text-red-600" : ""}
+        >
+          Logradouro <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("enderecoResidencial")}
+          id={enderecoResidencialId}
           onChange={(e) =>
             setValue("enderecoResidencial", e.target.value, {
               shouldValidate: true,
@@ -276,34 +295,48 @@ export const PersonalDataStep = () => {
           placeholder="Nome da rua / avenida, número"
           helperText={errors.enderecoResidencial?.message}
           error={!!errors.enderecoResidencial}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-endereco" }}
-          FormHelperTextProps={{ id: "error-endereco" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.enderecoResidencial && { "aria-describedby": "error-prof-endereco" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-endereco" }}
         />
       </div>
 
       <div ref={fieldRefs.numeroResidencial} className="flex flex-col gap-2">
-        <label className={errors.numeroResidencial ? "text-red-600" : ""}>
+        <label
+          htmlFor={numeroResidencialId}
+          className={errors.numeroResidencial ? "text-red-600" : ""}
+        >
           Número <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("numeroResidencial")}
+          id={numeroResidencialId}
           value={numeroResidencialValue}
           type="number"
           variant="outlined"
           placeholder="0000"
           helperText={errors.numeroResidencial?.message}
           error={!!errors.numeroResidencial}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-numero" }}
-          FormHelperTextProps={{ id: "error-numero" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.numeroResidencial && { "aria-describedby": "error-prof-numero" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-numero" }}
         />
       </div>
 
       <div ref={fieldRefs.bairroResidencial} className="flex flex-col gap-2">
-        <label className={errors.bairroResidencial ? "text-red-600" : ""}>
+        <label
+          htmlFor={bairroResidencialId}
+          className={errors.bairroResidencial ? "text-red-600" : ""}
+        >
           Bairro <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("bairroResidencial")}
+          id={bairroResidencialId}
           onChange={(e) =>
             setValue("bairroResidencial", e.target.value, {
               shouldValidate: true,
@@ -314,17 +347,24 @@ export const PersonalDataStep = () => {
           placeholder="Nome do bairro"
           helperText={errors.bairroResidencial?.message}
           error={!!errors.bairroResidencial}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-bairro" }}
-          FormHelperTextProps={{ id: "error-bairro" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.bairroResidencial && { "aria-describedby": "error-prof-bairro" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-bairro" }}
         />
       </div>
 
       <div ref={fieldRefs.cidadeResidencial} className="flex flex-col gap-2">
-        <label className={errors.cidadeResidencial ? "text-red-600" : ""}>
+        <label
+          htmlFor={cidadeResidencialId}
+          className={errors.cidadeResidencial ? "text-red-600" : ""}
+        >
           Cidade <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("cidadeResidencial")}
+          id={cidadeResidencialId}
           onChange={(e) =>
             setValue("cidadeResidencial", e.target.value, {
               shouldValidate: true,
@@ -335,17 +375,24 @@ export const PersonalDataStep = () => {
           placeholder="Nome da cidade"
           helperText={errors.cidadeResidencial?.message}
           error={!!errors.cidadeResidencial}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-cidade" }}
-          FormHelperTextProps={{ id: "error-cidade" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.cidadeResidencial && { "aria-describedby": "error-prof-cidade" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-cidade" }}
         />
       </div>
 
       <div ref={fieldRefs.estadoResidencial} className="flex flex-col gap-2">
-        <label className={errors.estadoResidencial ? "text-red-600" : ""}>
+        <label
+          htmlFor={estadoResidencialId}
+          className={errors.estadoResidencial ? "text-red-600" : ""}
+        >
           Estado <span className="text-red-600">*</span>
         </label>
         <TextField
           {...register("estadoResidencial")}
+          id={estadoResidencialId}
           onChange={(e) =>
             setValue("estadoResidencial", e.target.value, {
               shouldValidate: true,
@@ -356,8 +403,11 @@ export const PersonalDataStep = () => {
           placeholder="Nome do estado"
           helperText={errors.estadoResidencial?.message}
           error={!!errors.estadoResidencial}
-          inputProps={{ "aria-required": "true", "aria-describedby": "error-estado" }}
-          FormHelperTextProps={{ id: "error-estado" }}
+          inputProps={{
+            "aria-required": "true",
+            ...(errors.estadoResidencial && { "aria-describedby": "error-prof-estado" }),
+          }}
+          FormHelperTextProps={{ id: "error-prof-estado" }}
         />
       </div>
 

--- a/src/features/auth/components/ProfissionalRegister/SpecialtyStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/SpecialtyStep.tsx
@@ -92,7 +92,12 @@ export const SpecialtyStep = () => {
     <form onSubmit={onSubmit} className="flex flex-col gap-8">
       <span>Escolha as especialidades que irá fornecer atendimento *</span>
 
-      <ul role="listbox" aria-multiselectable="true" aria-label="Especialidades" className="flex flex-wrap gap-2">
+      <ul
+        role="listbox"
+        aria-multiselectable="true"
+        aria-label="Especialidades"
+        className="flex flex-wrap gap-2"
+      >
         {visibleSpecialties.map((specialty) => (
           <li
             key={specialty}

--- a/src/features/auth/components/ProfissionalRegister/SpecialtyStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/SpecialtyStep.tsx
@@ -36,7 +36,11 @@ const schema = z.object({
 });
 
 export const SpecialtyStep = () => {
-  const { setValue, handleSubmit } = useForm<Data>({
+  const {
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Data>({
     mode: "all",
     resolver: zodResolver(schema),
     defaultValues: { specialties: [], servicePreferences: [] },
@@ -90,7 +94,14 @@ export const SpecialtyStep = () => {
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-8">
-      <span>Escolha as especialidades que irá fornecer atendimento *</span>
+      <div className="flex flex-col gap-1">
+        <span>Escolha as especialidades que irá fornecer atendimento *</span>
+        {errors.specialties && (
+          <p className="text-red-600 text-sm" role="alert">
+            {errors.specialties.message}
+          </p>
+        )}
+      </div>
 
       <ul
         role="listbox"

--- a/src/features/auth/components/ProfissionalRegister/SpecialtyStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/SpecialtyStep.tsx
@@ -7,7 +7,7 @@ import { SuggestionForm } from "./SuggestionForm";
 import { useProfissionalRegisterStore } from "./useProfissionalRegisterStore";
 
 const specialtiesMock = [
-  "Acunputura",
+  "Acupuntura",
   "Aromaterapia",
   "Arteterapia",
   "Biodança",
@@ -92,11 +92,20 @@ export const SpecialtyStep = () => {
     <form onSubmit={onSubmit} className="flex flex-col gap-8">
       <span>Escolha as especialidades que irá fornecer atendimento *</span>
 
-      <ul className="flex flex-wrap gap-2">
+      <ul role="listbox" aria-multiselectable="true" aria-label="Especialidades" className="flex flex-wrap gap-2">
         {visibleSpecialties.map((specialty) => (
           <li
             key={specialty}
+            role="option"
+            aria-selected={selectedSpecialties.includes(specialty)}
+            tabIndex={0}
             onClick={handleClickSpecialty}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleClickSpecialty(e as any);
+              }
+            }}
             className={`cursor-pointer rounded rounded-t-lg rounded-br-lg border border-blue-800 p-2 transition-all hover:bg-blue-600/50 ${
               selectedSpecialties.includes(specialty) ? "bg-blue-600/50" : ""
             }`}

--- a/src/features/auth/hooks/useRegisterPatient.ts
+++ b/src/features/auth/hooks/useRegisterPatient.ts
@@ -12,6 +12,12 @@ export const useRegisterPatient = () => {
 
   return useMutation({
     mutationFn: async (data: ICreatePatient) => {
+      if (!pendingToken) {
+        toast.error("Sessão expirada. Por favor, faça o login novamente.");
+        router.push("/auth");
+        throw new Error("pendingToken ausente");
+      }
+
       const response = await api.post("/auth/createPatient", data, {
         headers: { Authorization: `Bearer ${pendingToken}` },
       });

--- a/src/features/auth/hooks/useRegisterPatient.ts
+++ b/src/features/auth/hooks/useRegisterPatient.ts
@@ -61,6 +61,7 @@ export const useRegisterPatient = () => {
       }
     },
     onError: (error) => {
+      if (error.message === "pendingToken ausente") return;
       toast.error(error.message);
     },
   });

--- a/src/features/auth/hooks/useRegisterPatient.ts
+++ b/src/features/auth/hooks/useRegisterPatient.ts
@@ -3,20 +3,24 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import toast from "react-hot-toast";
 import { api } from "@/libs/api";
+import { useUserStore } from "@/stores/userSessionStore";
 import type { ICreatePatient } from "@/types/patient";
 
 export const useRegisterPatient = () => {
   const router = useRouter();
+  const { pendingToken, clearPendingToken } = useUserStore();
 
   return useMutation({
     mutationFn: async (data: ICreatePatient) => {
-      const response = await api.post("/auth/createPatient", data);
+      const response = await api.post("/auth/createPatient", data, {
+        headers: { Authorization: `Bearer ${pendingToken}` },
+      });
 
       return response.data;
     },
     onSuccess: async (data) => {
+      clearPendingToken();
       try {
-        console.log("data:", data);
         const token = data.token;
 
         if (!token) {

--- a/src/features/auth/hooks/useRegisterPatient.ts
+++ b/src/features/auth/hooks/useRegisterPatient.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { signIn } from "next-auth/react";
+import { getSession, signIn } from "next-auth/react";
 import toast from "react-hot-toast";
 import { api } from "@/libs/api";
 import { useUserStore } from "@/stores/userSessionStore";
@@ -8,7 +8,7 @@ import type { ICreatePatient } from "@/types/patient";
 
 export const useRegisterPatient = () => {
   const router = useRouter();
-  const { pendingToken, clearPendingToken } = useUserStore();
+  const { pendingToken, clearPendingToken, setUser } = useUserStore();
 
   return useMutation({
     mutationFn: async (data: ICreatePatient) => {
@@ -34,6 +34,16 @@ export const useRegisterPatient = () => {
         });
 
         if (result?.ok) {
+          const session = await getSession();
+          if (session?.user) {
+            setUser({
+              id: (session.user as any).id ?? (session.user as any)._id,
+              email: session.user.email ?? "",
+              name: session.user.name ?? undefined,
+              photo: (session.user as any).profilePhoto ?? session.user.image ?? undefined,
+              type: (session as any).userType ?? undefined,
+            });
+          }
           toast.success("Cadastro realizado e sessão iniciada!");
           router.push("/");
         } else {

--- a/src/features/auth/hooks/useRegisterProfissional.ts
+++ b/src/features/auth/hooks/useRegisterProfissional.ts
@@ -3,18 +3,23 @@ import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import toast from "react-hot-toast";
 import { api } from "@/libs/api";
+import { useUserStore } from "@/stores/userSessionStore";
 import type { ICreateProfissional } from "@/types/professional";
 
 export const useRegisterProfissional = () => {
   const router = useRouter();
+  const { pendingToken, clearPendingToken } = useUserStore();
 
   return useMutation({
     mutationFn: async (data: ICreateProfissional) => {
-      const response = await api.post("/auth/createProfessional", data);
+      const response = await api.post("/auth/createProfessional", data, {
+        headers: { Authorization: `Bearer ${pendingToken}` },
+      });
 
       return response.data;
     },
     onSuccess: async (data) => {
+      clearPendingToken();
       try {
         const token = data.token;
 

--- a/src/features/auth/hooks/useRegisterProfissional.ts
+++ b/src/features/auth/hooks/useRegisterProfissional.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { signIn } from "next-auth/react";
+import { getSession, signIn } from "next-auth/react";
 import toast from "react-hot-toast";
 import { api } from "@/libs/api";
 import { useUserStore } from "@/stores/userSessionStore";
@@ -8,7 +8,7 @@ import type { ICreateProfissional } from "@/types/professional";
 
 export const useRegisterProfissional = () => {
   const router = useRouter();
-  const { pendingToken, clearPendingToken } = useUserStore();
+  const { pendingToken, clearPendingToken, setUser } = useUserStore();
 
   return useMutation({
     mutationFn: async (data: ICreateProfissional) => {
@@ -34,6 +34,16 @@ export const useRegisterProfissional = () => {
         });
 
         if (result?.ok) {
+          const session = await getSession();
+          if (session?.user) {
+            setUser({
+              id: (session.user as any).id ?? (session.user as any)._id,
+              email: session.user.email ?? "",
+              name: session.user.name ?? undefined,
+              photo: (session.user as any).profilePhoto ?? session.user.image ?? undefined,
+              type: (session as any).userType ?? undefined,
+            });
+          }
           toast.success("Cadastro realizado e sessão iniciada!");
           router.push("/");
         } else {

--- a/src/features/auth/hooks/useRegisterProfissional.ts
+++ b/src/features/auth/hooks/useRegisterProfissional.ts
@@ -60,6 +60,7 @@ export const useRegisterProfissional = () => {
       }
     },
     onError: (error) => {
+      if (error.message === "pendingToken ausente") return;
       toast.error(error.message);
     },
   });

--- a/src/features/auth/hooks/useRegisterProfissional.ts
+++ b/src/features/auth/hooks/useRegisterProfissional.ts
@@ -12,6 +12,12 @@ export const useRegisterProfissional = () => {
 
   return useMutation({
     mutationFn: async (data: ICreateProfissional) => {
+      if (!pendingToken) {
+        toast.error("Sessão expirada. Por favor, faça o login novamente.");
+        router.push("/auth");
+        throw new Error("pendingToken ausente");
+      }
+
       const response = await api.post("/auth/createProfessional", data, {
         headers: { Authorization: `Bearer ${pendingToken}` },
       });

--- a/src/stores/userSessionStore.ts
+++ b/src/stores/userSessionStore.ts
@@ -19,12 +19,15 @@ type UserStoreProps = {
   profilePhoto: string | null;
   userType: UserType;
   isAuthenticated: boolean;
+  pendingToken: string | null;
 
   setUser: (userData: UserData) => void;
   setUserType: (userType: UserType) => void;
   setExists: (exists: boolean) => void;
   setIdUser: (id: string) => void;
   setEmail: (email: string) => void;
+  setPendingToken: (token: string) => void;
+  clearPendingToken: () => void;
   clearSession: () => void;
 };
 
@@ -38,6 +41,7 @@ export const useUserStore = create<UserStoreProps>()(
       profilePhoto: null,
       userType: null,
       isAuthenticated: false,
+      pendingToken: null,
       setUser: (userData) => {
         set({
           idUser: userData.id,
@@ -54,6 +58,8 @@ export const useUserStore = create<UserStoreProps>()(
       setEmail: (email) => set({ email }),
       setUserType: (userType) => set({ userType }),
       setIdUser: (id) => set({ idUser: id }),
+      setPendingToken: (token) => set({ pendingToken: token }),
+      clearPendingToken: () => set({ pendingToken: null }),
       clearSession: () => {
         set({
           email: null,
@@ -63,6 +69,7 @@ export const useUserStore = create<UserStoreProps>()(
           profilePhoto: null,
           userType: null,
           isAuthenticated: false,
+          pendingToken: null,
         });
         if (typeof window !== "undefined") {
           sessionStorage.removeItem("user-session");
@@ -80,6 +87,7 @@ export const useUserStore = create<UserStoreProps>()(
         name: state.name,
         userType: state.userType,
         isAuthenticated: state.isAuthenticated,
+        pendingToken: state.pendingToken,
       }),
     },
   ),


### PR DESCRIPTION
## Summary

- **Fluxo de registro corrigido**: `pendingToken` enviado como `Bearer` nas rotas de criação; null guard com redirect em caso de sessão expirada; `getSession()` + `setUser()` após registro para popular estado de autenticação
- **Acessibilidade (WCAG)**: `htmlFor/id` em todos os campos dos formulários de paciente e profissional; `aria-describedby` condicional (referencia IDs apenas quando erro existe); `role=listbox/option` no SpecialtyStep; `aria-hidden` em ícones decorativos; `<button>` e `<Link>` separados corretamente no Header; `<main>` duplo removido das 5 páginas de auth
- **Validação**: regex de nome corrigido (`À-ÖØ-öø-ÿ`) para excluir `×` e `÷`; `required` nativo removido para permitir erros RHF; mensagem de erro inline nos dois SpecialtySteps quando nenhuma especialidade selecionada
- **Correções menores**: typos `"Acunputura"` → `"Acupuntura"`, `"Longradouro"` → `"Logradouro"`, `"voce"` → `"você"`

## Test Plan

- [ ] Fluxo completo de registro de paciente com email `@test.conectabem.com` e OTP `0000`
- [ ] Fluxo completo de registro de profissional com o mesmo bypass
- [ ] Submeter formulários vazios e verificar erros RHF em todos os campos
- [ ] Testar nome com `÷` e `×` — deve ser rejeitado
- [ ] Clicar Continuar sem selecionar especialidade — deve exibir erro inline
- [ ] Verificar no DevTools que todos os labels têm `for` associado ao `id` do input
- [ ] Rodar `npm test` — 57 testes passando

🤖 Shipped via [ship skill](https://github.com/tarcisiopgs/ship-skill)