### PR TITLE
fix(cypress): pular testes de bypass quando OTP_BYPASS_ENABLED não está ativo

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,9 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    env: {
+      OTP_BYPASS_ENABLED: process.env.CYPRESS_OTP_BYPASS_ENABLED === "true",
+    },
     setupNodeEvents(on, _config) {
       on("task", {
         log(message) {

--- a/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/cadastro.cy.js
+++ b/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/cadastro.cy.js
@@ -23,6 +23,12 @@ describe("Fluxo de Cadastro", () => {
   });
 
   context("Cadastro completo de paciente com bypass de OTP", () => {
+    before(function () {
+      if (!Cypress.env("OTP_BYPASS_ENABLED")) {
+        this.skip();
+      }
+    });
+
     it("Realiza cadastro completo usando email @test.conectabem.com e OTP 0000", () => {
       // Usa email único por execução para não colidir com runs anteriores
       const email = `qa-paciente-${Date.now()}@test.conectabem.com`;

--- a/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/login.bypass.cy.js
+++ b/cypress/e2e/navigation/Fluxo 1 - Login e Cadastro/login.bypass.cy.js
@@ -8,6 +8,12 @@ import { enterOTPCode } from "../../utils/mailtm.js";
  * `npm run seed:test-users` na API antes de executar essa suite.
  */
 describe("Login com bypass de OTP — usuários de teste", () => {
+  before(function () {
+    if (!Cypress.env("OTP_BYPASS_ENABLED")) {
+      this.skip();
+    }
+  });
+
   beforeEach(() => {
     cy.visit("/");
     cy.get(".MuiButtonBase-root").first().click();


### PR DESCRIPTION
## Summary
- Testes de bypass (`login.bypass.cy.js` e contexto de bypass em `cadastro.cy.js`) falhavam em CI porque `cypress.config.js` aponta para produção, onde `TEST_OTP_ENABLED` nunca está ativo
- Adicionado guard via `Cypress.env("OTP_BYPASS_ENABLED")`: sem essa variável os testes são pulados (skip) em vez de falhar
- A variável é controlada por `CYPRESS_OTP_BYPASS_ENABLED=true` no ambiente — para rodar localmente com bypass basta setar essa env

## Test Plan
- [ ] CI passa com os testes de bypass pulados (sem `CYPRESS_OTP_BYPASS_ENABLED`)
- [ ] Localmente com `CYPRESS_OTP_BYPASS_ENABLED=true` os testes ainda executam normalmente

🤖 Shipped via [ship skill](https://github.com/tarcisiopgs/ship-skill)