### PR TITLE
fix: corrige layout da etapa final do cadastro de profissional

### DIFF
--- a/src/features/auth/components/ProfissionalRegister/CompleteProfileStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/CompleteProfileStep.tsx
@@ -82,8 +82,6 @@ export const CompleteProfileStep = () => {
 
   return (
     <form className="flex flex-col gap-8">
-      <span>Estamos felizes em ter voce aqui, {name}. Vamos iniciar sua jornada?</span>
-
       <div className="relative flex items-center justify-center">
         <ImageUpload onChange={onChangeImage} value={photo} className="mb-4" />
       </div>

--- a/src/features/auth/components/ProfissionalRegister/Description.tsx
+++ b/src/features/auth/components/ProfissionalRegister/Description.tsx
@@ -2,7 +2,7 @@ import { FormMultiStep } from "@/components/FormMultiStep";
 import { useProfissionalRegisterStore } from "./useProfissionalRegisterStore";
 
 export const Description = () => {
-  const { step } = useProfissionalRegisterStore();
+  const { step, name } = useProfissionalRegisterStore();
 
   return (
     <>
@@ -17,6 +17,12 @@ export const Description = () => {
         <FormMultiStep.Description>
           Aqui você irá inserir suas informações iniciais de atendimento. Para cadastrar todos os
           seus dados acesse: perfil &gt; editar informações.
+        </FormMultiStep.Description>
+      )}
+
+      {step === "complete_profile" && (
+        <FormMultiStep.Description>
+          Estamos felizes em ter você aqui, {name}. Vamos iniciar sua jornada?
         </FormMultiStep.Description>
       )}
     </>

--- a/src/features/auth/components/ProfissionalRegister/index.tsx
+++ b/src/features/auth/components/ProfissionalRegister/index.tsx
@@ -22,24 +22,22 @@ export const ProfissionalRegister = () => {
   };
 
   return (
-    <div className="flex w-full flex-col bg-[#F3F5FA] pb-16">
-      <div className="flex w-full max-w-[450px] flex-col gap-16">
-        <FormMultiStep.Header className="gap-4">
-          <FormTitle />
-          <FormMultiStep.Progress progress={progresses[step]} />
-          <Description />
-        </FormMultiStep.Header>
+    <>
+      <FormMultiStep.Header className="gap-4">
+        <FormTitle />
+        <FormMultiStep.Progress progress={progresses[step]} />
+        <Description />
+      </FormMultiStep.Header>
 
-        {step === "personal_data" && <PersonalDataStep />}
-        {step === "service_location" && <ServiceLocationStep />}
-        {step === "specialties" && <SpecialtyStep />}
-        {step === "accessibility" && <AccessibilityStep />}
-        {step === "complete_profile" && <CompleteProfileStep />}
+      {step === "personal_data" && <PersonalDataStep />}
+      {step === "service_location" && <ServiceLocationStep />}
+      {step === "specialties" && <SpecialtyStep />}
+      {step === "accessibility" && <AccessibilityStep />}
+      {step === "complete_profile" && <CompleteProfileStep />}
 
-        {step !== "complete_profile" && (
-          <FormMultiStep.NeedHelpButton className="w-fit justify-start gap-2 text-gray-500" />
-        )}
-      </div>
-    </div>
+      {step !== "complete_profile" && (
+        <FormMultiStep.NeedHelpButton className="w-fit justify-start gap-2 text-gray-500" />
+      )}
+    </>
   );
 };


### PR DESCRIPTION
A etapa final do cadastro de profissional estava desalinhada.

O index.tsx tinha wrappers extras com estilos redundantes que conflitavam com
o layout da página pai. Além disso, o Description.tsx não tinha o caso
complete_profile, deixando o header sem descrição na última etapa. Por fim,
o texto de boas-vindas estava duplicado dentro do form no CompleteProfileStep.tsx,
deslocando o conteúdo.

Removi os wrappers desnecessários, adicionei o caso complete_profile no
Description.tsx e removi o span duplicado do CompleteProfileStep.tsx.