### PR TITLE
Fix/mobile detection usemediaquery

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -12,6 +12,10 @@ import { FilterDialogDesktop } from "@/features/search/components/FilterDialogDe
 import { FilterPanelMobile } from "@/features/search/components/FilterPanelMobile";
 import type { FiltersState } from "@/features/search/components/types";
 
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
 export default function HomePage() {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const defaultFilters: FiltersState = {
@@ -23,6 +27,7 @@ export default function HomePage() {
     distance: 12,
   };
   const [filters, setFilters] = useState<FiltersState>(defaultFilters);
+  const isMobile = useIsMobile();
 
   const onFilterChange = () => {
     setIsFilterOpen((prev) => !prev);
@@ -35,8 +40,8 @@ export default function HomePage() {
   const handleClearFilters = () => {
     setFilters(defaultFilters);
   };
-
-  if (isFilterOpen && typeof window !== "undefined" && window.innerWidth < 768) {
+  
+  if (isFilterOpen && isMobile) {
     return <FilterPanelMobile onFilterChange={onFilterChange} />;
   }
 

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -11,9 +11,6 @@ import { FilterButton } from "@/features/search/components/FilterButton";
 import { FilterDialogDesktop } from "@/features/search/components/FilterDialogDesktop";
 import { FilterPanelMobile } from "@/features/search/components/FilterPanelMobile";
 import type { FiltersState } from "@/features/search/components/types";
-
-import { useTheme } from "@mui/material/styles";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
 export default function HomePage() {
@@ -40,7 +37,7 @@ export default function HomePage() {
   const handleClearFilters = () => {
     setFilters(defaultFilters);
   };
-  
+
   if (isFilterOpen && isMobile) {
     return <FilterPanelMobile onFilterChange={onFilterChange} />;
   }

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -81,4 +81,5 @@ function SearchPage() {
     </div>
   );
 }
+
 export default SearchPage;

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -11,8 +11,10 @@ import { FilterPanelMobile } from "@/features/search/components/FilterPanelMobil
 import type { FiltersState } from "@/features/search/components/types";
 import { useFilterProfessional } from "@/features/search/hooks/useFilterProfessional";
 import type { IProfessional } from "@/types/professional";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 function SearchPage() {
+  const isMobile = useIsMobile();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const defaultFilters: FiltersState = {
     specialties: [],
@@ -37,7 +39,7 @@ function SearchPage() {
     setFilters(defaultFilters);
   };
 
-  if (isFilterOpen && typeof window !== "undefined" && window.innerWidth < 768) {
+  if (isFilterOpen && isMobile) {
     return <FilterPanelMobile onFilterChange={onFilterChange} />;
   }
 

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -3,5 +3,5 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 
 export function useIsMobile() {
   const theme = useTheme();
-  return useMediaQuery(theme.breakpoints.down("md"));
+  return useMediaQuery(theme.breakpoints.down("sm"));
 }

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,7 +1,5 @@
-import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 export function useIsMobile() {
-  const theme = useTheme();
-  return useMediaQuery(theme.breakpoints.down("sm"));
+  return useMediaQuery("(max-width: 767.98px)");
 }

--- a/src/hooks/useIsMobile.tsx
+++ b/src/hooks/useIsMobile.tsx
@@ -1,0 +1,7 @@
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+export function useIsMobile() {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down("md"));
+}


### PR DESCRIPTION
- Criado um hook reutilizável (useIsMobile) para centralizar a lógica de detecção de dispositivo mobile
- Substituída a verificação manual window.innerWidth por useMediaQuery do MUI
- Removida lógica não reativa de detecção de tela, evitando problemas com resize e hydration mismatch no Next.js
- Aplicada a nova abordagem de responsividade na Home e na página de Search
- Reduzida duplicação de código ao evitar repetição da lógica de breakpoint em múltiplos arquivos
- Melhorada a consistência do comportamento responsivo em toda a aplicação
- Código alinhado com boas práticas de React + Next.js + MUI para responsividade