### PR TITLE
chore: ignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 
 *storybook.log
 .env*.local
+
+# claude code
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.gitignore` so per-developer Claude Code settings stop showing up as untracked files

## Test plan
- [x] `git check-ignore -v .claude/settings.local.json` resolves to the new rule
- [x] `git status` no longer reports the file