### PR TITLE
feat: Update the state field to display the full name instead of the …

### DIFF
--- a/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/PatientRegister/PersonalDataStep.tsx
@@ -178,7 +178,7 @@ export const PersonalDataStep = () => {
     setValue("cidadeResidencial", data.localidade || "", {
       shouldValidate: true,
     });
-    setValue("estadoResidencial", data.estado || data.uf || "", {
+    setValue("estadoResidencial", data.uf || "", {
       shouldValidate: true,
     });
   }, [data, setValue]);

--- a/src/features/auth/components/ProfissionalRegister/PersonalDataStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/PersonalDataStep.tsx
@@ -193,7 +193,7 @@ export const PersonalDataStep = () => {
     setValue("enderecoResidencial", data.logradouro);
     setValue("bairroResidencial", data.bairro);
     setValue("cidadeResidencial", data.localidade);
-    setValue("estadoResidencial", data.estado);
+    setValue("estadoResidencial", data.uf);
     setValue("numeroResidencial", "");
   }, [data, setValue]);
 

--- a/src/features/auth/components/ProfissionalRegister/ServiceLocationStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/ServiceLocationStep.tsx
@@ -153,7 +153,7 @@ export const ServiceLocationStep = () => {
     setNeighborhoodInput(data.bairro || "");
 
     setValue("cidadeClinica", data.localidade);
-    setValue("estadoClinica", data.estado);
+    setValue("estadoClinica", data.uf);
   }, [data, setValue]);
 
   return (


### PR DESCRIPTION
## Ajuste de campos de estado nos formulários

Padronização para usar apenas o campo `uf` (sigla) retornado pela API ViaCEP em todos os formulários de cadastro (paciente e profissional).

**Arquivos modificados:**
- `src/features/auth/components/PatientRegister/PersonalDataStep.tsx`
- `src/features/auth/components/ProfessionalRegister/PersonalDataStep.tsx`
- `src/features/auth/components/ProfessionalRegister/ServiceLocationStep.tsx`