### PR TITLE
fix(search): paginação da searchbar troca de página

### DIFF
--- a/src/features/search/hooks/useFilterProfessional.ts
+++ b/src/features/search/hooks/useFilterProfessional.ts
@@ -1,6 +1,9 @@
 import type { FiltersState } from "@/features/search/components/types";
 import { useGetSearchProfessionals } from "@/kubb/hooks/useGetSearchProfessionals";
-import { useGetSearchSearchbarTerms } from "@/kubb/hooks/useGetSearchSearchbarTerms";
+import {
+  getSearchSearchbarTermsQueryKey,
+  useGetSearchSearchbarTerms,
+} from "@/kubb/hooks/useGetSearchSearchbarTerms";
 import { type RawProfessional, toProfessionalCardProps } from "@/utils/toProfessionalCardProps";
 
 type UseFilterProfessionalParams = {
@@ -26,8 +29,17 @@ export const useFilterProfessional = ({
     { query: { enabled: !hasSearchTerm } },
   );
 
+  // Workaround: the generated `useGetSearchSearchbarTerms` hook declares `page`
+  // as a path param in the OpenAPI spec, but the actual URL is
+  // `/search/searchBar/:terms` — so `page` is never sent and the queryKey
+  // doesn't change between pages. We inject `page` both into the queryKey
+  // (so React Query refetches) and as a real query string param.
   const searchQuery = useGetSearchSearchbarTerms(searchTerm, page, {
-    query: { enabled: hasSearchTerm },
+    query: {
+      enabled: hasSearchTerm,
+      queryKey: [...getSearchSearchbarTermsQueryKey(searchTerm, page), { page }] as const,
+    },
+    client: { params: { page } },
   });
 
   const activeQuery = hasSearchTerm ? searchQuery : filterQuery;


### PR DESCRIPTION
## O que muda

`useFilterProfessional` passa `page` no `queryKey` do React Query e como query string `?page=N` na chamada do `useGetSearchSearchbarTerms`.

## Por quê

Hook gerado pelo Kubb (`useGetSearchSearchbarTerms`) tem `page` declarado como path param na spec OpenAPI, mas a URL montada é só `/search/searchBar/:terms` — não tem placeholder `:page`. Resultado:

1. `page` nunca chega no backend
2. queryKey não muda quando a página muda → React Query devolve o cache da página 1 pra sempre

Foi o bug que o @MateusFelS reportou na #210 (clicar em "próxima página" não troca os resultados).

## Fix proposto

Workaround no wrapper. Estende o `queryKey` com `{ page }` pra invalidar o cache, e injeta `page` como `params` do axios pra mandar como query string na request.

## Followup

O fix definitivo é arrumar a spec OpenAPI no backend (declarar `page` como query param em vez de path). Quando isso for feito e o Kubb for regenerado, esse workaround pode sair. Vou abrir issue separada no backend.

## Test plan

- [ ] `/search` com termo digitado: clicar "Próxima" troca os cards
- [ ] DevTools Network: requests pra `/search/searchBar/:terms` carregam `?page=2` etc
- [ ] Voltar pra página 1 funciona
- [ ] Trocar termo de busca volta pra página 1 (já funcionava)

Closes parcial #210.