### PR TITLE
feat(home): paginação real em destaques e seções por especialidade

### DIFF
--- a/src/features/home/components/HighlightWeek.tsx
+++ b/src/features/home/components/HighlightWeek.tsx
@@ -1,17 +1,38 @@
 "use client";
 
+import { useState } from "react";
 import { useHighlightWeek } from "../hooks/useHighlightWeek";
 import { ProfessionalCard } from "./ProfessionalCard";
 
 export const HighlightWeek = () => {
-  const { data, isLoading, isError } = useHighlightWeek(1);
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isError, pageCount } = useHighlightWeek(page);
+  const hasMore = page < pageCount;
+  const canGoBack = page > 1;
 
   return (
     <section className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <p className="font-semibold text-2xl">Destaques da semana</p>
-        <div className="cursor-pointer font-semibold underline decoration-2 underline-offset-4">
-          + Ver Mais
+        <div className="flex items-center gap-3">
+          {canGoBack && (
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="cursor-pointer font-semibold underline decoration-2 underline-offset-4"
+            >
+              Anterior
+            </button>
+          )}
+          {hasMore && (
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              className="cursor-pointer font-semibold underline decoration-2 underline-offset-4"
+            >
+              + Ver Mais
+            </button>
+          )}
         </div>
       </div>
       <ProfessionalCard professionals={data} isLoading={isLoading} isError={isError} />

--- a/src/features/home/components/ProfessionalSection.tsx
+++ b/src/features/home/components/ProfessionalSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useProfessionalBySpeciality } from "../hooks/useProfessionalBySpeciality";
 import { useUserPatient } from "../hooks/useUserPatient";
 import { ProfessionalCard } from "./ProfessionalCard";
@@ -7,14 +8,37 @@ import { ProfessionalCard } from "./ProfessionalCard";
 type Speciality = { id: number; name: string };
 
 const SpecialitySectionItem = ({ speciality }: { speciality: Speciality }) => {
-  const { data, isLoading, isError } = useProfessionalBySpeciality(speciality.name, 1);
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isError, pageCount } = useProfessionalBySpeciality(
+    speciality.name,
+    page,
+  );
+  const hasMore = page < pageCount;
+  const canGoBack = page > 1;
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <p className="font-semibold text-2xl">{speciality.name}</p>
-        <div className="cursor-pointer font-semibold underline decoration-2 underline-offset-4">
-          + Ver Mais
+        <div className="flex items-center gap-3">
+          {canGoBack && (
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="cursor-pointer font-semibold underline decoration-2 underline-offset-4"
+            >
+              Anterior
+            </button>
+          )}
+          {hasMore && (
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              className="cursor-pointer font-semibold underline decoration-2 underline-offset-4"
+            >
+              + Ver Mais
+            </button>
+          )}
         </div>
       </div>
       <ProfessionalCard professionals={data} isLoading={isLoading} isError={isError} />

--- a/src/features/home/hooks/useHighlightWeek.ts
+++ b/src/features/home/hooks/useHighlightWeek.ts
@@ -1,10 +1,28 @@
-import { useGetSearchHighlightsweek } from "@/kubb/hooks/useGetSearchHighlightsweek";
+import {
+  getSearchHighlightsweekQueryKey,
+  useGetSearchHighlightsweek,
+} from "@/kubb/hooks/useGetSearchHighlightsweek";
 import { toProfessionalCardProps } from "@/utils/toProfessionalCardProps";
 
 export function useHighlightWeek(page = 1) {
-  const { data, isLoading, isError } = useGetSearchHighlightsweek(page);
+  // Workaround: the Kubb-generated hook declares `page` as a path param,
+  // but the URL is `/search/highlightsWeek` — `page` is never sent and
+  // the queryKey doesn't change between pages. Inject `page` into the
+  // queryKey so React Query refetches, and forward it as a real query
+  // string param.
+  const { data, isLoading, isError } = useGetSearchHighlightsweek(page, {
+    query: {
+      queryKey: [...getSearchHighlightsweekQueryKey(page), { page }] as const,
+    },
+    client: { params: { page } },
+  });
 
   const professionals = (data?.professionals ?? []).map(toProfessionalCardProps);
 
-  return { data: professionals, isLoading, isError };
+  return {
+    data: professionals,
+    isLoading,
+    isError,
+    pageCount: data?.pageCount ?? 1,
+  };
 }

--- a/src/features/home/hooks/useProfessionalBySpeciality.ts
+++ b/src/features/home/hooks/useProfessionalBySpeciality.ts
@@ -1,14 +1,34 @@
-import { useGetSearchProfessionalbyspecialitySpeciality } from "@/kubb/hooks/useGetSearchProfessionalbyspecialitySpeciality";
+import {
+  getSearchProfessionalbyspecialitySpecialityQueryKey,
+  useGetSearchProfessionalbyspecialitySpeciality,
+} from "@/kubb/hooks/useGetSearchProfessionalbyspecialitySpeciality";
 import { toProfessionalCardProps } from "@/utils/toProfessionalCardProps";
 
 export function useProfessionalBySpeciality(speciality: string, page = 1) {
+  // Workaround: the Kubb-generated hook declares `page` as a path param,
+  // but the URL only has `:speciality`. Inject `page` into the queryKey
+  // so React Query refetches, and forward it as a real query string param.
   const { data, isLoading, isError } = useGetSearchProfessionalbyspecialitySpeciality(
     speciality,
     page,
-    { query: { enabled: !!speciality } },
+    {
+      query: {
+        enabled: !!speciality,
+        queryKey: [
+          ...getSearchProfessionalbyspecialitySpecialityQueryKey(speciality, page),
+          { page },
+        ] as const,
+      },
+      client: { params: { page } },
+    },
   );
 
   const professionals = (data?.professionals ?? []).map(toProfessionalCardProps);
 
-  return { data: professionals, isLoading, isError };
+  return {
+    data: professionals,
+    isLoading,
+    isError,
+    pageCount: data?.pageCount ?? 1,
+  };
 }


### PR DESCRIPTION
## O que muda

Home agora pagina de verdade tanto na seção de destaques quanto nas seções por especialidade. O "+ Ver Mais" deixa de ser decorativo.

## Por quê

@MateusFelS sinalizou na #209 que a Home só renderiza os primeiros 10 cards e o critério de aceite "Seção de destaques funciona com paginação" não tava cumprido. Tem dois problemas empilhados:

1. **Bug nos hooks Kubb** — `useGetSearchHighlightsweek` e `useGetSearchProfessionalbyspecialitySpeciality` declaram `page` como path param na spec OpenAPI, mas as URLs são `/search/highlightsWeek` e `/search/professionalBySpeciality/:speciality`. Não tem `:page` em lugar nenhum. Resultado: `page` nunca chega no backend e nem entra no `queryKey` → React Query sempre devolve a página 1 do cache.

2. **UI sem controle de paginação** — `HighlightWeek` e `SpecialitySectionItem` chamavam `useHighlightWeek(1)` / `useProfessionalBySpeciality(name, 1)` hardcoded. O "+ Ver Mais" era um `div` estático.

## Fix proposto

Workaround nos wrappers (mesma ideia do PR #227 pro searchbar):

- `useHighlightWeek` e `useProfessionalBySpeciality` injetam `page` no `queryKey` e mandam como `?page=N` via axios `params`. Ambos passam a expor `pageCount` da resposta.
- `HighlightWeek` e `SpecialitySectionItem` ganham `useState` de `page` e renderizam botões `Anterior` / `+ Ver Mais` gateados em `page > 1` e `page < pageCount`.

## Followup

Fix definitivo é arrumar a spec OpenAPI no backend pra `page` virar query param em todos esses 3 endpoints (highlightsWeek, professionalBySpeciality, searchBar). Quando isso for regenerado pelo Kubb, os 3 workarounds (esse PR + #227) podem sair. Vou abrir issue separada no repo do back.

## Test plan

- [ ] Home: seção de destaques carrega cards reais
- [ ] "+ Ver Mais" só aparece se `pageCount > 1`
- [ ] Clicar "+ Ver Mais" carrega a próxima página dos destaques (Network: `?page=2`)
- [ ] "Anterior" volta pra página anterior
- [ ] Mesmo comportamento em cada seção por especialidade (Acupuntura, Reiki, etc)
- [ ] Botões somem nos extremos (página 1 esconde "Anterior", última esconde "+ Ver Mais")

Closes parcial #209.