### PR TITLE
fix(search): ler profissionais e pageCount do filterQuery

### DIFF
--- a/src/features/search/hooks/useFilterProfessional.ts
+++ b/src/features/search/hooks/useFilterProfessional.ts
@@ -44,16 +44,23 @@ export const useFilterProfessional = ({
 
   const activeQuery = hasSearchTerm ? searchQuery : filterQuery;
 
+  // Both `/search/searchBar/:terms` and `/search/professionals` return
+  // `{ professionals, page, pageCount, ... }`. The previous code assumed
+  // `/search/professionals` returned a bare array and lost both the
+  // results and the pageCount. The Kubb-generated type for the filter
+  // endpoint is `any`, so we have to narrow defensively.
+  const filterData = filterQuery.data as
+    | { professionals?: RawProfessional[]; pageCount?: number }
+    | undefined;
+
   const rawList: RawProfessional[] = hasSearchTerm
     ? (searchQuery.data?.professionals ?? [])
-    : Array.isArray(filterQuery.data)
-      ? (filterQuery.data as RawProfessional[])
-      : [];
+    : (filterData?.professionals ?? []);
 
   return {
     data: rawList.map(toProfessionalCardProps),
     isLoading: activeQuery.isLoading,
     isError: activeQuery.isError,
-    pageCount: hasSearchTerm ? (searchQuery.data?.pageCount ?? 1) : 1,
+    pageCount: hasSearchTerm ? (searchQuery.data?.pageCount ?? 1) : (filterData?.pageCount ?? 1),
   };
 };


### PR DESCRIPTION
## Bugs

Dois problemas relacionados em \`useFilterProfessional\`:

### 1. Resultados sumiam quando filtro estava ativo (sem termo de busca)

O hook assumia que \`useGetSearchProfessionals\` devolvia um \`RawProfessional[]\` direto e usava \`Array.isArray(filterQuery.data)\` pra escolher o resultado. O backend de fato devolve:

\`\`\`json
{ \"professionals\": [...], \"page\": 1, \"pageCount\": 2, \"total\": 14, \"hasMore\": true }
\`\`\`

\`Array.isArray\` é sempre \`false\` nesse shape → \`rawList\` caía no fallback \`[]\` → cards filtrados nunca renderizavam.

### 2. Paginação invisível no /search

\`pageCount\` estava hardcoded como \`1\` sempre que o usuário não tava usando a busca por texto. Os botões de paginação só apareciam pra busca, nunca pro filtro — mesmo quando o backend reportava várias páginas.

Verifiquei isso em produção: \`/search\` chamou \`/search/professionals?page=1\` e o backend retornou \`pageCount: 2, total: 14, hasMore: true\`. Front mostrou só os 5 primeiros e nenhum botão de paginação.

## Fix

Lê \`professionals\` e \`pageCount\` direto do response do filterQuery. O tipo Kubb gerado pra \`GetSearchProfessionals200\` é \`any\`, então fiz um narrow inline pra manter a story do TypeScript honesta.

## Test plan

- [ ] \`/search\` carrega a lista completa (até 10 cards na primeira página)
- [ ] Botões \"Anterior\" / \"Próxima\" aparecem quando \`pageCount > 1\`
- [ ] Clicar \"Próxima\" carrega segunda página de profissionais
- [ ] Aplicar filtro de especialidade → paginação ainda funciona com o subset filtrado
- [ ] Tests Jest 58/58 passam (\`npm test\`)

Refs #195