### PR TITLE
fix(layout): footer não voa mais em páginas curtas

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -16,8 +16,8 @@ export default function Layout({
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
-      <div className="mx-auto min-h-[40vh] w-full max-w-[86rem] px-10 py-10 lg:flex lg:items-center lg:justify-center">
-        <main className="flex-1">{children}</main>
+      <div className="mx-auto flex w-full max-w-[86rem] flex-1 flex-col px-10 py-10 lg:flex-row lg:items-start lg:justify-center">
+        <main className="w-full flex-1">{children}</main>
       </div>
       {isLoggedIn ? (
         <Footer


### PR DESCRIPTION
## Bug

@MateusFelS reportou no QA da #210: \"o footer tbm está voando, não está no fim da página\". Reproduz fácil em \`/search\` quando dá \"Nenhum profissional encontrado.\" ou \"Erro ao carregar profissionais.\" — o footer renderiza no meio da tela com bastante espaço branco abaixo dele.

## Causa raiz

O layout do route group \`(public)\` envolvia \`<main>\` num \`<div>\` com \`min-h-[40vh]\` mas sem \`flex-1\`:

\`\`\`tsx
<div className=\"flex min-h-screen flex-col\">
  <Header />
  <div className=\"... min-h-[40vh] ...\">
    <main className=\"flex-1\">{children}</main>
  </div>
  <Footer ... />
</div>
\`\`\`

O outer é \`flex-col min-h-screen\`. O middle wrapper só pede \`min-h-[40vh]\` — sem \`flex-1\`, ele não cresce pra preencher o espaço vertical. Resultado: quando o conteúdo é curto, o middle ocupa só ~40vh, o footer renderiza logo depois e sobra branco até o fim da viewport.

## Fix

- Middle wrapper agora é \`flex flex-1 flex-col\` (cresce no flex-col outer)
- \`<main>\` continua \`flex-1\` (preenche o middle)
- Centralização horizontal desktop migrou pro mesmo wrapper (\`lg:flex-row lg:items-start lg:justify-center\`)

Layout visual de páginas com bastante conteúdo não muda. Só o footer para de boiar em páginas curtas.

## Test plan

- [ ] \`/search\` sem resultado → footer cola no fim da viewport
- [ ] \`/search\` com bastante card → layout idêntico ao de antes
- [ ] Home (\`/\`) com seções carregadas → idêntico
- [ ] Mobile e desktop OK
- [ ] Tests Jest 58/58 passam

Refs #210