### PR TITLE
fix(auth): destravar Continuar no AuthForm e na etapa 2/5 do cadastro profissional

### DIFF
--- a/src/features/auth/components/AuthForm/AuthForm.tsx
+++ b/src/features/auth/components/AuthForm/AuthForm.tsx
@@ -28,6 +28,7 @@ export const AuthForm = () => {
     handleSubmit,
     formState: { errors, isValid },
   } = useForm<Data>({
+    mode: "onChange",
     resolver: zodResolver(schema),
   });
 


### PR DESCRIPTION
## Resumo

Dois bugs distintos travavam o fluxo de cadastro com a mesma sintomatologia (botão "Continuar" sem efeito, sem feedback, sem request, sem erro no console). Reportados pelo Mateus em [QualityAssurance / Cadastro Profissional Travado](https://github.com/developmentHC/QualityAssurance/blob/main/Relatorios%20e%20Comunica%C3%A7%C3%A3o/Relatorio%20de%20Bugs/Relat%C3%B3rio%20de%20Testes%20-%20Cadastro%20Profissional%20Travado.md).

### Bug 1 — `AuthForm` (tela de e-mail `/auth`)

`useForm` sem `mode` definido usa default `onSubmit`, então `formState.isValid` só atualiza após o primeiro submit. Como o botão usava `disabled={!isValid}`, ficava preso em `disabled` e o clique virava no-op.

**Fix:** `mode: "onChange"` em `AuthForm.tsx`.

### Bug 2 — `ServiceLocationStep` (etapa 2/5 do cadastro profissional)

Schema exigia `estadoClinica` com `min(3)`, mas a UF retornada pelo ViaCEP tem sempre 2 chars (SP, RJ, etc). Resultado: validação falhava sempre. Como o campo de estado não é exibido na UI e o `handleSubmit` não tinha handler `onInvalid`, o erro virava silêncio total.

**Fix:**
- `estadoClinica.min(2)` no schema (compatível com UF).
- Handler `onInvalid` no `handleSubmit` que dispara toast com a primeira mensagem de erro, evitando futuras falhas silenciosas em campos invisíveis.

## Test plan

- [x] Stack local subido (Mongo via Docker + API + Web)
- [x] `/auth` com email vazio → botão `disabled=true` (esperado)
- [x] Email válido digitado → botão habilita reativamente → click envia OTP → toast "Código enviado com sucesso!" → navega pra `/auth/confirmar-codigo`
- [x] Fluxo completo até etapa 2/5 (profissional) com CEP `01310-100` (SP) → click em Continuar avança pra etapa 3/5 (Especialidades)
- [ ] Validar em homologação após merge