### PR TITLE
fix(auth): destravar Continuar na etapa 2/5 do cadastro profissional

### DIFF
--- a/src/features/auth/components/ProfissionalRegister/ServiceLocationStep.tsx
+++ b/src/features/auth/components/ProfissionalRegister/ServiceLocationStep.tsx
@@ -3,6 +3,7 @@ import { Button, TextField } from "@mui/material";
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
 import { z } from "zod";
 import { CEPField } from "@/components/Fields/CEPField";
 import { CpfCnpjField } from "@/components/Fields/CpfCnpjField";
@@ -61,7 +62,7 @@ const schema = z.object({
     .min(1, "O número deve ser maior que 0"),
   complementoClinica: z.string(),
   cidadeClinica: z.string().min(3, "Cidade inválida"),
-  estadoClinica: z.string().min(3, "Estado inválido"),
+  estadoClinica: z.string().min(2, "Estado inválido"),
 });
 
 type Data = z.infer<typeof schema>;
@@ -132,16 +133,26 @@ export const ServiceLocationStep = () => {
     setValue("complementoClinica", onlyLettersAndSpace);
   };
 
-  const onSubmit = handleSubmit(async (data) => {
-    data.cepProfessional = data.cepProfessional.replace("-", "");
-    data.cpfCNPJ = data.cpfCNPJ.replace(".", "").replace(".", "").replace("-", "").replace("/", "");
+  const onSubmit = handleSubmit(
+    async (data) => {
+      data.cepProfessional = data.cepProfessional.replace("-", "");
+      data.cpfCNPJ = data.cpfCNPJ
+        .replace(".", "")
+        .replace(".", "")
+        .replace("-", "")
+        .replace("/", "");
 
-    updateFields(data);
+      updateFields(data);
 
-    window.scrollTo({ top: 0, behavior: "smooth" });
+      window.scrollTo({ top: 0, behavior: "smooth" });
 
-    changeStep("specialties");
-  });
+      changeStep("specialties");
+    },
+    (formErrors) => {
+      const firstError = Object.values(formErrors)[0];
+      if (firstError?.message) toast.error(firstError.message);
+    },
+  );
 
   useEffect(() => {
     if (!data) return;


### PR DESCRIPTION
## Resumo

Continuação do bug reportado pelo Mateus em [QualityAssurance / Cadastro Profissional Travado](https://github.com/developmentHC/QualityAssurance/blob/main/Relatorios%20e%20Comunica%C3%A7%C3%A3o/Relatorio%20de%20Bugs/Relat%C3%B3rio%20de%20Testes%20-%20Cadastro%20Profissional%20Travado.md). O #232 corrigiu o trava do `AuthForm` (tela de e-mail), mas o report tinha um segundo bug na etapa 2/5 do cadastro profissional, com sintomas idênticos (Continuar sem efeito, sem feedback, sem request, sem erro no console).

## Causa raiz

`ServiceLocationStep` definia `estadoClinica: z.string().min(3)`, mas a UF retornada pelo ViaCEP tem sempre 2 chars (SP, RJ, etc). Resultado: validação falhava 100% das vezes. Como o campo de estado não é exibido na UI (vem invisível, preenchido pelo CEP) e o `handleSubmit` não tinha handler `onInvalid`, o erro virava silêncio total.

## Fix

- `estadoClinica.min(2)` no schema (compatível com UF de 2 chars).
- Handler `onInvalid` no `handleSubmit` que dispara toast com a primeira mensagem de erro, evitando futuras falhas silenciosas em campos invisíveis.

```diff
-  estadoClinica: z.string().min(3, "Estado inválido"),
+  estadoClinica: z.string().min(2, "Estado inválido"),
```

```diff
- const onSubmit = handleSubmit(async (data) => { ... });
+ const onSubmit = handleSubmit(
+   async (data) => { ... },
+   (formErrors) => {
+     const firstError = Object.values(formErrors)[0];
+     if (firstError?.message) toast.error(firstError.message);
+   },
+ );
```

## Test plan

- [x] Stack local subido (Mongo via Docker + API + Web)
- [x] Fluxo completo até etapa 2/5 com CEP `01310-100` (SP) → click em Continuar avança pra etapa 3/5 (Especialidades)
- [ ] Validar em homologação após merge